### PR TITLE
properly sanitizes method names for non-empty JUnit Parameters name values

### DIFF
--- a/src/main/java/com/coremedia/testing/junit/SpringAware.java
+++ b/src/main/java/com/coremedia/testing/junit/SpringAware.java
@@ -73,7 +73,7 @@ public class SpringAware extends TestWatcher {
         testContextManager.beforeTestClass();
       } else if (description.isTest()) {
         LOG.debug("Preparing test {}#{}.", description.getClassName(), description.getMethodName());
-        TEST_METHOD.set(description.getTestClass().getMethod(description.getMethodName()));
+        TEST_METHOD.set(description.getTestClass().getMethod(sanitizeMethodName(description.getMethodName())));
         testContextManager.beforeTestMethod(getTestInstance(), getTestMethod());
       }
     } catch (final Exception e) {
@@ -123,5 +123,16 @@ public class SpringAware extends TestWatcher {
       throw new SpringAwareException("Failed to prepare test instance.", e);
     }
     return this;
+  }
+
+  private String sanitizeMethodName(String methodName) {
+      assert(methodName != null);
+
+      final int startBracketPosition = methodName.indexOf('[');
+      if (startBracketPosition == -1) {
+          return methodName;
+      }
+
+      return methodName.substring(0, startBracketPosition);
   }
 }

--- a/src/test/java/com/coremedia/testing/junit/ParameterizedSpringAwareTest.java
+++ b/src/test/java/com/coremedia/testing/junit/ParameterizedSpringAwareTest.java
@@ -1,0 +1,58 @@
+package com.coremedia.testing.junit;
+
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+
+import javax.inject.Inject;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+@TestExecutionListeners({DependencyInjectionTestExecutionListener.class})
+@ContextConfiguration
+@RunWith(Parameterized.class)
+public class ParameterizedSpringAwareTest {
+
+  @ClassRule
+  public static final SpringAware SPRING_AWARE =
+      SpringAware.forClass(MethodHandles.lookup().lookupClass());
+  @Rule
+  public TestRule springAwareMethod =
+      SPRING_AWARE.forInstance(this);
+  @Inject
+  private ApplicationContext applicationContext;
+
+  @Parameterized.Parameters(name = "\"{0}\".equals({1})")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(new Object[][]{
+        {"yes", "yes"},
+        {"no", "no"}
+    });
+  }
+
+  private final String input;
+  private final String expected;
+
+  public ParameterizedSpringAwareTest(String input, String expected) {
+    this.input = input;
+    this.expected = expected;
+  }
+
+  @Test
+  public void test() {
+    assertThat(input, is(expected));
+    assertThat("Bean ApplicationContext should exist.", applicationContext, notNullValue());
+  }
+}

--- a/src/test/resources/com/coremedia/testing/junit/ParameterizedSpringAwareTest-context.xml
+++ b/src/test/resources/com/coremedia/testing/junit/ParameterizedSpringAwareTest-context.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans
+                            http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+</beans>


### PR DESCRIPTION
Example:

``` java
@Parameterized.Parameters(name = "Phone number: assertValid(\"{0}\") == {1}")
public static Collection<Object[]> data() {
    return Arrays.asList(new Object[][]{
        {"7776665555", true},
        {"abc", false}
    });
}
```

Without the method name getting sanitized these tests fail because the result of `description.getMethodName()` is actually something like `test[Phone number: assert...]()` which causes an exception when trying to invoke the method on the test class.
